### PR TITLE
Only dump FQCN with leading \ when there is a namespace

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -289,7 +289,8 @@ final class CodeGenerator
             match (true) {
                 $import && $byParent => $this->importByParent($fqcn),
                 $import => $this->import($fqcn),
-                default => '\\' . $fqcn,
+                $this->namespace !== null => '\\' . $fqcn,
+                default => $fqcn,
             },
         );
     }

--- a/tests/CodeGeneratorTest.php
+++ b/tests/CodeGeneratorTest.php
@@ -452,12 +452,22 @@ final class CodeGeneratorTest extends TestCase
     public function testDumpClassReferenceWithoutImport() : void
     {
         self::assertSame(
-            '\\App\\Models\\User::class',
+            'App\\Models\\User::class',
             $this->generator->dumpClassReference('App\\Models\\User', false),
         );
         self::assertSame(
-            '\\App\\Models\\User::class',
+            'App\\Models\\User::class',
             $this->generator->dumpClassReference('\\App\\Models\\User', false),
+        );
+
+        $generator = new CodeGenerator('App');
+        self::assertSame(
+            '\\App\\Models\\User::class',
+            $generator->dumpClassReference('App\\Models\\User', false),
+        );
+        self::assertSame(
+            '\\App\\Models\\User::class',
+            $generator->dumpClassReference('\\App\\Models\\User', false),
         );
     }
 


### PR DESCRIPTION
When there is no namespace defined, using the leading \ is redundant.
