### PR TITLE
Add trailing comma via suffixLast when addCommaAfterEachArgument is false

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -639,7 +639,7 @@ final class CodeGenerator
                 }
 
                 yield sprintf('->%s(', $method);
-                yield Group::indent($addCommaAfterEachArgument ? $this->allSuffix(',', $args) : $args);
+                yield Group::indent($addCommaAfterEachArgument ? $this->allSuffix(',', $args) : $this->suffixLast(',', $args));
                 yield ')';
             });
 
@@ -668,7 +668,7 @@ final class CodeGenerator
         }
 
         yield sprintf('%s(', $call);
-        yield Group::indent($addCommaAfterEachArgument ? $this->allSuffix(',', $args) : $args);
+        yield Group::indent($addCommaAfterEachArgument ? $this->allSuffix(',', $args) : $this->suffixLast(',', $args));
         yield ')';
     }
 

--- a/tests/CodeGeneratorTest.php
+++ b/tests/CodeGeneratorTest.php
@@ -1025,6 +1025,51 @@ final class CodeGeneratorTest extends TestCase
         );
     }
 
+    public function testDumpCallWithoutCommaAfterEachArgumentAddsTrailingComma() : void
+    {
+        $this->assertDump(
+            <<<'PHP'
+                Helper::process(
+                    match (true) {
+                        $a => 1,
+                        default => 2,
+                    },
+                )
+                PHP,
+            $this->generator->dumpCall('App\\Utils\\Helper', 'process', [
+                'match (true) {',
+                $this->generator->indent(function () {
+                    yield '$a => 1,';
+                    yield 'default => 2,';
+                }),
+                '}',
+            ], true, false),
+        );
+    }
+
+    public function testDumpCallOnIterableWithoutCommaAfterEachArgumentAddsTrailingComma() : void
+    {
+        $this->assertDump(
+            <<<'PHP'
+                $object
+                    ->method(
+                        match (true) {
+                            $a => 1,
+                            default => 2,
+                        },
+                    )
+                PHP,
+            $this->generator->dumpCall(['$object'], 'method', [
+                'match (true) {',
+                $this->generator->indent(function () {
+                    yield '$a => 1,';
+                    yield 'default => 2,';
+                }),
+                '}',
+            ], false, false),
+        );
+    }
+
     public function testDumpFileWithNoImportsHasNoExtraNewline() : void
     {
         $this->generator = new CodeGenerator('App\\Services');


### PR DESCRIPTION
## Summary

When `addCommaAfterEachArgument` is `false` in `dumpCall`, no commas were added at all. PHP CS Fixer expects a trailing comma on the last argument in multiline function calls.

This changes the `false` behavior to use `suffixLast(',', $args)` instead of just `$args`, adding a comma only to the last argument line. This is useful for multi-line constructs like `match` expressions used as function arguments:

```php
// Before (no trailing comma after })
Type::nonNull(
    match (true) {
        $a => $this->getType('Foo'),
        default => $this->getType('Bar'),
    }
)

// After (trailing comma on last argument only)
Type::nonNull(
    match (true) {
        $a => $this->getType('Foo'),
        default => $this->getType('Bar'),
    },
)
```

Both the static call path and object call path are updated.

## Test plan

- [x] Added tests for both static and iterable object call paths
- [x] Full test suite passes (167 tests, 308 assertions)