### PR TITLE
Reserve same-namespace short names during import

### DIFF
--- a/src/CodeGenerator.php
+++ b/src/CodeGenerator.php
@@ -214,8 +214,14 @@ final class CodeGenerator
 
         // Check if the class is in the same namespace as the current namespace
         if ($this->namespace !== null && $fqcn->namespace !== null && $this->namespace->equals($fqcn->namespace)) {
-            // No import needed, just return the class name
-            return (string) $fqcn->className;
+            // No import needed, but reserve the short name so later imports from
+            // other namespaces are aliased instead of colliding with the local
+            // declaration (PHP would reject `use X\Y\Foo;` in a file that also
+            // declares `class Foo`).
+            $alias = (string) $fqcn->className;
+            $this->imports[$alias] ??= $fqcn;
+
+            return $alias;
         }
 
         $alias = $this->findAvailableAlias($fqcn, $fqcn->className->name);

--- a/tests/CodeGeneratorTest.php
+++ b/tests/CodeGeneratorTest.php
@@ -170,6 +170,31 @@ final class CodeGeneratorTest extends TestCase
         );
     }
 
+    public function testImportClassConflictsWithSameNamespaceDeclaration() : void
+    {
+        $this->generator = new CodeGenerator('App\\Models');
+
+        $local = $this->generator->import('App\\Models\\User');
+        $external = $this->generator->import('App\\Domain\\User');
+
+        self::assertSame('User', $local);
+        self::assertSame('User2', $external);
+
+        $this->assertDumpFile(
+            <<<'PHP'
+                <?php
+
+                declare(strict_types=1);
+
+                namespace App\Models;
+
+                use App\Domain\User as User2;
+
+                PHP,
+            [],
+        );
+    }
+
     public function testImportFunction() : void
     {
         $alias = $this->generator->import(new FunctionName('array_map'));


### PR DESCRIPTION
When a class is imported with the same namespace as the current file, its short name is now recorded as a reserved alias rather than silently returned. Without the reservation, a later import from a different namespace with the same short name was also returned unaliased, so the generated file ended up with `use X\Y\Foo;` alongside a `class Foo` declaration — which PHP rejects as a redeclaration.

`findAvailableAlias` already bumps colliding entries to `Foo2`, so recording the reservation is enough to make conflicting external imports flow through that path automatically.
